### PR TITLE
chore: add CI, shared scheme, architecture doc, and screenshot wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Test (iOS Simulator)
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      # Secrets.swift is gitignored (it holds the Gemini + Unsplash API keys).
+      # CI writes a placeholder so the project compiles; the stub keys are not
+      # valid, so any live API call falls back to mock/offline behavior. No real
+      # backend is contacted during a build/unit-test run.
+      - name: Write stub Secrets.swift
+        run: |
+          cat > Edutok/Secrets.swift <<'SWIFT'
+          import Foundation
+
+          // CI placeholder. Real keys live in a gitignored Secrets.swift on dev
+          // machines (see README "Getting started"). These values are non-functional.
+          enum Secrets {
+              static let geminiAPIKey = "CI_STUB_GEMINI_KEY"
+              static let unsplashAccessKey = "CI_STUB_UNSPLASH_KEY"
+          }
+          SWIFT
+
+      # GoogleService-Info.plist is gitignored (it holds the project's Firebase
+      # client config). CI writes a syntactically valid placeholder so the
+      # Firebase resource-copy phase and FirebaseApp.configure() succeed; no
+      # real backend is contacted during a build/unit-test run.
+      - name: Write stub GoogleService-Info.plist
+        run: |
+          cat > Edutok/GoogleService-Info.plist <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>API_KEY</key><string>AIzaStubKeyForCIBuildsOnly000000000000</string>
+            <key>GCM_SENDER_ID</key><string>000000000000</string>
+            <key>PLIST_VERSION</key><string>1</string>
+            <key>BUNDLE_ID</key><string>com.billdmar.Edutok</string>
+            <key>PROJECT_ID</key><string>edutok-ci-stub</string>
+            <key>STORAGE_BUCKET</key><string>edutok-ci-stub.appspot.com</string>
+            <key>IS_ADS_ENABLED</key><false/>
+            <key>IS_ANALYTICS_ENABLED</key><false/>
+            <key>IS_APPINVITE_ENABLED</key><true/>
+            <key>IS_GCM_ENABLED</key><true/>
+            <key>IS_SIGNIN_ENABLED</key><true/>
+            <key>GOOGLE_APP_ID</key><string>1:000000000000:ios:0000000000000000000000</string>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Resolve Swift packages
+        run: xcodebuild -resolvePackageDependencies -project Edutok.xcodeproj -scheme Edutok
+
+      - name: Build & test
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project Edutok.xcodeproj \
+            -scheme Edutok \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+            -derivedDataPath .build/DerivedData \
+            -only-testing:EdutokTests \
+            CODE_SIGNING_ALLOWED=NO

--- a/Edutok.xcodeproj/xcshareddata/xcschemes/Edutok.xcscheme
+++ b/Edutok.xcodeproj/xcshareddata/xcschemes/Edutok.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0896654B2E42D31100FEE0A3"
+               BuildableName = "Edutok.app"
+               BlueprintName = "Edutok"
+               ReferencedContainer = "container:Edutok.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "089665592E42D31400FEE0A3"
+               BuildableName = "EdutokTests.xctest"
+               BlueprintName = "EdutokTests"
+               ReferencedContainer = "container:Edutok.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0896654B2E42D31100FEE0A3"
+            BuildableName = "Edutok.app"
+            BlueprintName = "Edutok"
+            ReferencedContainer = "container:Edutok.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0896654B2E42D31100FEE0A3"
+            BuildableName = "Edutok.app"
+            BlueprintName = "Edutok"
+            ReferencedContainer = "container:Edutok.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Edutok/ImageManager.swift
+++ b/Edutok/ImageManager.swift
@@ -94,8 +94,8 @@ class ImageManager: ObservableObject {
                 }
             }
 
-            let response = try JSONDecoder().decode(GeminiResponse.self, from: data)
-            if let keywords = response.candidates.first?.content.parts.first?.text {
+            let decoded = try JSONDecoder().decode(GeminiResponse.self, from: data)
+            if let keywords = decoded.candidates.first?.content.parts.first?.text {
                 return keywords.trimmingCharacters(in: .whitespacesAndNewlines)
             }
         } catch {

--- a/Edutok/TopicManager.swift
+++ b/Edutok/TopicManager.swift
@@ -209,9 +209,9 @@ class TopicManager: ObservableObject {
             }
         }
 
-        let response = try JSONDecoder().decode(GeminiResponse.self, from: data)
+        let decoded = try JSONDecoder().decode(GeminiResponse.self, from: data)
 
-        guard let firstCandidate = response.candidates.first,
+        guard let firstCandidate = decoded.candidates.first,
               let firstPart = firstCandidate.content.parts.first else {
             throw APIError.invalidResponse
         }

--- a/EdutokTests/EdutokTests.swift
+++ b/EdutokTests/EdutokTests.swift
@@ -7,6 +7,7 @@
 //  with no Firebase or network dependency.
 //
 
+import Foundation
 import Testing
 
 @testable import Edutok

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 Edutok is an iOS app that turns any topic into a TikTok-style feed of bite-sized, AI-generated flashcards — wrapped in streaks, achievements, and a leaderboard to make learning genuinely addictive.
 
+[![CI](https://github.com/billdmar/Edutok/actions/workflows/ci.yml/badge.svg)](https://github.com/billdmar/Edutok/actions/workflows/ci.yml)
 ![Swift](https://img.shields.io/badge/Swift-5-orange?logo=swift&logoColor=white)
 ![iOS](https://img.shields.io/badge/iOS-18.5%2B-000000?logo=apple&logoColor=white)
 ![SwiftUI](https://img.shields.io/badge/UI-SwiftUI-0071e3)
@@ -33,7 +34,7 @@ Edutok is an iOS app that turns any topic into a TikTok-style feed of bite-sized
 | AI content      | Google Gemini (`gemini-1.5-flash-latest`)    |
 | Images          | Unsplash API                          |
 | Auth & database | Firebase Auth + Cloud Firestore       |
-| Architecture    | MVVM with `ObservableObject` managers |
+| Architecture    | MVVM with `ObservableObject` managers — see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
 
 ## Architecture
 
@@ -140,18 +141,16 @@ This project keeps all credentials out of version control:
 
 ## Screenshots
 
-> 📸 Screenshots are being captured in the iOS Simulator and will land here shortly.
-> See [docs/SCREENSHOTS.md](docs/SCREENSHOTS.md) for the capture plan.
+> 📸 The images below render once the PNGs are added to `docs/` — see
+> [docs/SCREENSHOTS.md](docs/SCREENSHOTS.md) for how to capture them.
 
-<!-- Uncomment once the PNGs are committed to docs/.
-| Flashcard feed | Topic generation | Gamification |
+| Flashcard feed | Topic entry | Gamification |
 | :--: | :--: | :--: |
-| ![Feed](docs/feed.png) | ![Generate](docs/generate.png) | ![Gamification](docs/gamification.png) |
+| ![Flashcard feed](docs/feed.png) | ![Topic entry](docs/topic.png) | ![Gamification](docs/gamification.png) |
 
 | Streak calendar | Leaderboard |
 | :--: | :--: |
-| ![Streak](docs/streak.png) | ![Leaderboard](docs/leaderboard.png) |
--->
+| ![Streak calendar](docs/streak.png) | ![Leaderboard](docs/leaderboard.png) |
 
 ## Roadmap
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,295 @@
+# Edutok Architecture
+
+Edutok is a SwiftUI iOS app (iOS 18.5+) that turns any topic into a TikTok-style
+feed of AI-generated flashcards, wrapped in a gamification layer (XP, streaks,
+achievements, daily challenges, mystery boxes) and a Firebase-backed leaderboard.
+
+This document describes how the pieces fit together, grounded in the actual source
+under `Edutok/`. Where something is a stub, fallback, or known limitation, it is
+called out explicitly.
+
+## Design at a glance
+
+State is split across four `@MainActor` `ObservableObject` "manager" types, each
+owning a single domain. They are created once in the app entry point and injected
+into the SwiftUI view tree (either as `environmentObject`s or accessed via a shared
+singleton). Because every manager is `@MainActor`, published state mutates on the
+main thread and the UI updates without data races.
+
+| Manager | Lifetime | Responsibility |
+| --- | --- | --- |
+| `TopicManager` | `@StateObject` in `FlashTokApp`, injected as `environmentObject` | Generates flashcards via Gemini; persists topics to `UserDefaults` |
+| `GamificationManager` | `@StateObject` in `FlashTokApp`, injected as `environmentObject` | XP/levels, daily challenges, mystery boxes, achievements, notifications |
+| `FirebaseManager` | `.shared` singleton (`@StateObject` references) | Auth + Firestore profile, daily stats, streaks, leaderboard |
+| `ImageManager` | `.shared` singleton | Resolves + caches Unsplash image URLs per card |
+
+## Data-flow diagram
+
+```
+                         ┌──────────────────────────────────────────┐
+                         │  FlashTokApp (@main, App.swift)            │
+                         │  • AppDelegate → FirebaseApp.configure()   │
+                         │  • owns TopicManager, GamificationManager  │
+                         │  • references FirebaseManager.shared       │
+                         │  • anonymous sign-in on launch             │
+                         └───────────────────┬──────────────────────┘
+                                             │ environmentObjects
+                                             ▼
+                         ┌──────────────────────────────────────────┐
+                         │  ContentView (root router)                 │
+                         │  AppSection: .main/.flashcards/            │
+                         │              .leaderboard/.calendar        │
+                         │  + floating bottom nav bar                 │
+                         └──┬─────────────┬──────────────┬───────────┘
+                            │             │              │
+              currentTopic==nil      currentTopic!=nil   │
+                            ▼             ▼              ▼
+                   ┌─────────────┐  ┌─────────────┐  ┌──────────────────┐
+                   │  MainView   │  │FlashcardView│  │ LeaderboardWrapper│
+                   │ topic entry │  │ swipe feed  │  │ StandaloneCalendar│
+                   └──────┬──────┘  └──────┬──────┘  └────────┬─────────┘
+                          │ generateFlashcards    │ swipes / flips     │ fetchDailyLeaderboard
+                          ▼                        ▼                    ▼
+   ┌───────────────┐   ┌──────────────────────────────────────┐   ┌───────────────────┐
+   │  ImageManager  │◄──┤            TopicManager               │   │   FirebaseManager  │
+   │ (Unsplash +    │   │  fetchFlashcardsFromGemini()          │   │  Auth + Firestore  │
+   │  Gemini kw)    │   │  → mock fallback on failure           │   │  trackCardFlipped  │
+   └──────┬─────────┘   │  persists Topics → UserDefaults        │   │  trackTopicExplored│
+          │             └───────────────┬──────────────────────┘   │  updateStreak      │
+          │ HTTPS                        │ NotificationCenter         │  daily leaderboard │
+          ▼                              ▼ "TopicExplored"            └─────────┬──────────┘
+   api.unsplash.com          ┌──────────────────────────┐                      │ HTTPS
+   generativelanguage        │   GamificationManager     │                      ▼
+   .googleapis.com           │ XP/levels, challenges,    │              Cloud Firestore
+   (Gemini 1.5 Flash)        │ mystery boxes, achievements│             (users, leaderboards)
+                             │ persists → UserDefaults    │
+                             │ UNUserNotificationCenter   │
+                             └──────────────────────────┘
+```
+
+## App entry & structure
+
+`App.swift` defines `@main struct FlashTokApp` (the product/scheme is named
+**Edutok**; the SwiftUI `App` type retains the project's original "FlashTok" name).
+It:
+
+- Registers an `AppDelegate` via `@UIApplicationDelegateAdaptor`, whose
+  `didFinishLaunchingWithOptions` calls `FirebaseApp.configure()`.
+- Creates `TopicManager`, `GamificationManager`, and references
+  `FirebaseManager.shared` as `@StateObject`s.
+- Injects `topicManager` and `gamificationManager` as `environmentObject`s and
+  forces `.preferredColorScheme(.dark)`.
+- On appear: schedules a study-reminder local notification and, if not already
+  authenticated, kicks off `FirebaseManager.signInAnonymously()`.
+
+`ContentView` is the root router. It holds `currentSection: AppSection`
+(`.main`, `.flashcards`, `.leaderboard`, `.calendar`) and renders the matching
+screen, plus a floating bottom navigation bar (Leaderboard / Learn / Calendar)
+shown only on the non-study sections. Selecting a topic (`topicManager.currentTopic
+!= nil`) auto-switches to the flashcard feed via `onChange`.
+
+`Color`/`View` extensions in `ContentView.swift` define the app's purple/pink/blue
+palette (`flashTokPurple`, `flashTokPink`, `flashTokBlue`) and a `flashTokStyle()`
+gradient modifier.
+
+## The swipeable card feed
+
+`FlashcardView` is the TikTok-style feed. Key mechanics (verified in the source):
+
+- It renders an **infinite scroll stack** (`infiniteCards`) of `ZStack`ed cards,
+  drawing the previous / current / next cards (relative index within ±2) for smooth
+  transitions, with TikTok-style offset/scale transitions per card.
+- A `DragGesture` on the current card maps gestures to actions:
+  - **Swipe up** → `nextCard()`
+  - **Swipe down** → `previousCard()`
+  - **Swipe right** (≥ 2× threshold) → `markAsUnderstood()` then `nextCard()`
+  - **Swipe left** (≥ 2× threshold) → `toggleBookmark()` (bounces back to center)
+  - Velocity (`predictedEndTranslation`) is also considered for up/down.
+  - `UIImpactFeedbackGenerator` fires haptics on each committed swipe.
+- Tapping a card flips it between question and answer (`showAnswer`,
+  `cardRotation`).
+- The feed grows endlessly: when nearing the end of the deck it calls
+  `topicManager.generateMoreFacts(for:)` to append another batch.
+- Side effects on interaction:
+  - First flip of a card → `FirebaseManager.shared.trackCardFlipped()`.
+  - Marking understood → `TopicManager.markCardAsUnderstood(...)` and
+    `GamificationManager.awardXP(.perfectCard)`; completion also calls
+    `awardXPForCardCompletion(wasCorrect:isFirstTry:timeToAnswer:)`.
+  - XP is awarded at most once per card (`cardXPAwarded: Set<UUID>`).
+
+## Gemini-powered flashcard generation
+
+`TopicManager` (`@MainActor`) owns the user's topics and is the single source of
+truth for the active topic. It persists `savedTopics` to `UserDefaults` (key
+`"SavedTopics"`) as JSON.
+
+Generation flow (`fetchFlashcardsFromGemini(topic:batchNumber:)`):
+
+1. Builds a `POST` to
+   `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=<Secrets.geminiAPIKey>`.
+2. The prompt (`createEnhancedFactsPrompt`) asks for **exactly 15 cards** as JSON,
+   and varies *focus aspect* and *depth level* by `batchNumber` so an "endless"
+   feed keeps getting deeper instead of repeating
+   (`getEnhancedTopicAspect` / `getDepthLevel`).
+3. `generationConfig`: `temperature 0.7`, `maxOutputTokens 3000`, `topP 0.8`;
+   request `timeoutInterval` 20s.
+4. The response is decoded into a nested `GeminiResponse` struct; the first
+   candidate's text is sanitized by `cleanJSONResponse` (strips ```` ```json ````
+   fences, normalizes smart quotes, narrows to the outer `[ ... ]` array) and then
+   decoded into typed `Flashcard`s. The card `type` string is normalized into the
+   `FlashcardType` enum (`definition` / `question` / `truefalse` / `fillblank`),
+   defaulting to `.question`.
+
+**Resilience / fallback:** any failure path — bad URL, non-200 HTTP, missing
+candidates, non-UTF-8 text, or decode error — throws `APIError.invalidResponse`,
+and the caller falls back to `createEnhancedMockFlashcards(for:)`, a fixed set of
+15 topic-templated cards. The feed is therefore **never empty** and the app degrades
+gracefully offline. Each generated/mock card is then assigned an image URL via
+`ImageManager` before the topic is saved and activated.
+
+`generateMoreFacts(for:)` advances the batch number (`flashcards.count / 15 + 2`)
+and appends the next batch, with the same fallback behavior.
+
+> **Note:** `Secrets.geminiAPIKey` / `Secrets.unsplashAccessKey` live in
+> `Edutok/Secrets.swift`, which is **gitignored** and supplied per developer (CI
+> writes a non-functional stub so the project compiles — see below).
+
+## Image fetching (Unsplash + Gemini keywords)
+
+`ImageManager` (`.shared`, `@MainActor`) resolves a relevant image URL per card and
+caches results in two bounded `NSCache`s (`countLimit = 500` each):
+
+1. `generateImageKeywords(for:topic:)` asks Gemini (same model endpoint) to produce
+   3–4 specific visual search keywords for the card. On any failure it returns a
+   fallback string derived from the topic + question text — it always returns a
+   usable value.
+2. Those keywords are queried against the Unsplash search API
+   (`https://api.unsplash.com/search/photos?...&client_id=<Secrets.unsplashAccessKey>`,
+   landscape, `per_page=5`) and one of the results is chosen for variety
+   (`generateDiverseImageForFlashcard(question:topic:variation:)`).
+3. Non-200 responses (401 invalid key, 403 rate-limited, etc.) and decode failures
+   return `nil`, in which case the card simply shows its gradient placeholder.
+
+## Firebase Auth + Firestore: data model & sync
+
+`FirebaseManager` (`.shared`, `@MainActor`) is the single entry point for auth and
+persistence. It configures Firebase once (guarding against double-`configure`),
+installs an auth state listener, and on sign-in loads-or-creates the user's profile.
+
+**Auth.** Supports anonymous sign-in (used automatically on launch),
+email/password sign-in & sign-up, and phone-number verification
+(`signInWithPhone` / `verifyPhoneCode`). Phone auth requires extra Firebase Console
+setup and "may not work in simulator" (noted in code).
+
+**User document (`users/{uid}`)** — mirrors `AppUser` (`FirebaseModels.swift`):
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `username` | String | Random `AdjectiveNounNNN` by default; capped at 30 chars |
+| `totalCardsFlipped` | Int | |
+| `totalTopicsExplored` | Int | |
+| `currentStreak` / `longestStreak` | Int | |
+| `lastActiveDate` / `joinDate` | Timestamp | |
+| `dailyStats` | Array | per-day `DailyStat`: `date`, `cardsFlipped`, `topicsExplored`, `achievements[]` |
+
+**Activity tracking.** `trackCardFlipped()` / `trackTopicExplored()` /
+`trackAchievement(_:)` bump totals, update (or create) today's `DailyStat`, refresh
+the streak (`updateStreak`), persist the user, and update the relevant leaderboard.
+`updateStreak` increments the current streak when there was activity today and
+either yesterday or a zero starting streak, tracks `longestStreak`, and resets to 0
+on an inactive day.
+
+**Leaderboards.** Two per-day collections, `daily_cards_leaderboard` and
+`daily_topics_leaderboard`, keyed `"{yyyy-MM-dd}_{uid}"`. `fetchDailyLeaderboard`
+queries the top 50 by descending value, filters to today's documents by the
+`documentID` date prefix, flags the current user, and assigns 1-based ranks.
+
+**Resilience.** Firestore writes are best-effort (`try?`) so transient backend
+failures never crash the app; if a profile can't be loaded, an in-memory fallback
+`AppUser` is created so the app remains usable offline.
+
+## Gamification system
+
+`GamificationManager` (`@MainActor`) drives all reward mechanics; the value types
+live in `GamificationModels.swift` and `Models.swift`. Progress persists to
+`UserDefaults`; key milestones mirror to Firebase via `FirebaseManager`.
+
+- **XP & levels.** `UserProgress` tracks `totalXP` as the single source of truth and
+  recomputes `currentLevel` from it. The level curve is quadratic:
+  `levelToXPRequired(n) = ((n-1)² · 50) + ((n-1) · 50)` — so **L2 = 100, L3 = 300,
+  L4 = 600**. `addXP(_:)` is a pure mutating function returning whether the gain
+  produced a level-up (used to trigger the level-up animation). XP amounts come from
+  the `XPReward` enum (e.g. `cardCompleted = 10`, `correctAnswer = 15`,
+  `perfectCard = 25`, `topicCompleted = 100`, `streakBonus = 20`).
+- **Daily challenges.** Three challenges generated per day (Card Master, Perfect
+  Score, Topic Explorer), each with a target, XP reward, and an `expiresAt` set to
+  the start of tomorrow. Progress is advanced via `updateChallengeProgress(type:)`;
+  topic-exploration progress arrives over `NotificationCenter` (`"TopicExplored"`,
+  posted by `TopicManager`) — a deliberately loose coupling between the two managers.
+- **Mystery boxes.** 3–5 boxes generated per session with a variable-ratio rarity
+  schedule — **50% common / 30% rare / 15% epic / 5% legendary** (see
+  `randomRarity()` and `BoxRarity.xpRange`). Opening a box awards XP in its rarity
+  range. This is a documented behavioral-design choice (see
+  [gamification-design.md](gamification-design.md)).
+- **Achievements.** Two systems coexist: the original `Achievement` enum (First
+  Steps, Scholar, Speed Demon, Night Owl, Explorer, Perfectionist, Dedicated,
+  Unstoppable — each with title/description/emoji/XP) and the newer
+  `EnhancedAchievement` value type with rarity + category (`AchievementRarity`,
+  `AchievementCategory`), checked by `checkEnhancedAchievements()`.
+- **Celebrations & notifications.** Level-ups, achievements, and box openings emit
+  particle effects (`ParticleEffectsView`) and toast/animation state. Local
+  notifications (`UNUserNotificationCenter`) cover study reminders, encouragement,
+  and streak warnings.
+- **Streaks.** Streak counting for the *profile/leaderboard* lives in
+  `FirebaseManager.updateStreak`; the streak calendar UI
+  (`StreakCalendarView` / `StandaloneCalendarView`) visualizes `DailyStat` activity
+  with `ActivityLevel` heat-map shading.
+
+## Persistence summary
+
+| Data | Store | Key / collection |
+| --- | --- | --- |
+| Saved topics & flashcards | `UserDefaults` (JSON) | `SavedTopics` |
+| XP / level progress | `UserDefaults` (JSON) | `UserProgress` |
+| Daily challenges | `UserDefaults` (JSON) | `DailyChallenges` |
+| Mystery boxes | `UserDefaults` (JSON) | `MysteryBoxes` |
+| Enhanced achievements | `UserDefaults` (JSON) | `EnhancedAchievements` |
+| Image URL cache | in-memory `NSCache` (bounded) | — |
+| User profile, daily stats | Cloud Firestore | `users/{uid}` |
+| Leaderboards | Cloud Firestore | `daily_cards_leaderboard`, `daily_topics_leaderboard` |
+
+## Secrets, configuration & CI
+
+- **`Edutok/Secrets.swift`** (gitignored) must define
+  `enum Secrets { static let geminiAPIKey; static let unsplashAccessKey }`.
+  The source references these directly; without the file the project will not
+  compile.
+- **`Edutok/GoogleService-Info.plist`** (gitignored) holds the Firebase client
+  config consumed at `FirebaseApp.configure()`.
+- Dependencies are managed via **Swift Package Manager** in the `.pbxproj`
+  (Firebase iOS SDK: `FirebaseAuth`, `FirebaseCore`, `FirebaseFirestore`). There is
+  no Podfile or `Package.swift`.
+- **CI** (`.github/workflows/ci.yml`) runs on `macos-15`. Because both files above
+  are gitignored, CI writes a **non-functional stub `Secrets.swift`** and a
+  **valid placeholder `GoogleService-Info.plist`** before resolving packages, so the
+  project compiles and `FirebaseApp.configure()` succeeds. The stub keys are not
+  valid, so no real backend is contacted during a build/unit-test run.
+
+## Testing
+
+Unit tests in `EdutokTests` (Swift Testing framework) cover the **pure domain
+logic** with no Firebase/network dependency: the XP/leveling math (thresholds,
+level-up detection, in-level progress), topic progress percentage, and reward
+ranges. CI runs only `-only-testing:EdutokTests`. `EdutokUITests` exists as the
+standard UI-test target but is not exercised in CI.
+
+## Known stubs & limitations
+
+- The SwiftUI `App` type is still named `FlashTokApp` (legacy "FlashTok" name); the
+  product/scheme/bundle is **Edutok**.
+- `MainView` has a "Refresh" button on Trending Topics and an inline
+  "search suggestions" block that are placeholders / no-ops in the current source.
+- Phone auth is wired but requires Firebase Console setup and may not work in the
+  simulator.
+- Generated images depend on a valid Unsplash key; without one (or on rate-limit)
+  cards fall back to gradient placeholders.

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -1,53 +1,49 @@
-# Capturing screenshots for the README
+# Screenshots
 
-The README's Screenshots tables expect five PNGs in this `docs/` folder:
-`feed.png`, `generate.png`, `gamification.png`, `streak.png`, `leaderboard.png`.
+The README's Screenshots section and the slots below expect five PNGs in this
+`docs/` folder. Until you add them they render as broken images — that's expected.
 
-## 1. Install an iOS simulator (one time)
-Xcode ▸ **Settings… ▸ Components** (older Xcode: **Platforms**) ▸ download an
-**iOS** simulator runtime (~7 GB).
-
-## 2. Add your real keys (required for live content)
-Edutok calls Google Gemini + Unsplash and uses Firebase, so for screenshots that
-show real AI-generated flashcards you need:
-
-1. Create `Edutok/Secrets.swift` (gitignored — never commit it):
-   ```swift
-   enum Secrets {
-       static let geminiAPIKey = "YOUR_REAL_GEMINI_KEY"
-       static let unsplashAccessKey = "YOUR_REAL_UNSPLASH_KEY"
-   }
-   ```
-2. Drop your real `GoogleService-Info.plist` (from the Firebase console) into
-   `Edutok/` (also gitignored).
-
-> Without these, the app builds but the feed stays empty and the leaderboard
-> won't populate — so the keys are what make the screenshots compelling.
-
-## 3. Run the app
-1. Open `Edutok.xcodeproj`, pick an **iPhone 16 Pro** simulator, press **⌘R**.
-2. Sign in / create an account, enter a topic (e.g. "Roman Empire") and let the
-   AI generate the flashcard feed.
-
-## 4. Capture each screen
-Focus the simulator and press **⌘S** (File ▸ Save Screen) for a device-framed PNG.
-
-| Filename | What to show |
+| Slot | What to show |
 | --- | --- |
-| `feed.png` | The swipeable flashcard feed with a generated card + its image |
-| `generate.png` | The topic-entry / generation screen |
-| `gamification.png` | XP/level, achievements, or a mystery-box / celebration moment |
-| `streak.png` | The streak calendar view |
-| `leaderboard.png` | The global leaderboard |
+| ![Flashcard feed](feed.png) | `feed.png` — the swipeable flashcard feed with a generated card + its image |
+| ![Topic entry](topic.png) | `topic.png` — the topic-entry / "Start Learning" screen |
+| ![Gamification](gamification.png) | `gamification.png` — XP/level, achievements, or a mystery-box / celebration moment |
+| ![Streak calendar](streak.png) | `streak.png` — the streak calendar view |
+| ![Leaderboard](leaderboard.png) | `leaderboard.png` — the global leaderboard |
 
-## 5. Drop them in and push
-```bash
-# rename captured PNGs to the names above, then:
-cp ~/Desktop/{feed,generate,gamification,streak,leaderboard}.png docs/
-git add docs/*.png
-git commit -m "docs: add app screenshots"
-git push
-```
-The README tables render them automatically.
+## How to capture
+
+1. **Add an iOS simulator** (one time): Xcode ▸ **Settings… ▸ Components** (older
+   Xcode: **Platforms**) ▸ download an **iOS** simulator runtime.
+2. **Add your real keys** (so the feed shows real content). Edutok calls Google
+   Gemini + Unsplash and uses Firebase, so for compelling screenshots:
+   - Create `Edutok/Secrets.swift` (gitignored — never commit it):
+     ```swift
+     import Foundation
+
+     enum Secrets {
+         static let geminiAPIKey = "YOUR_REAL_GEMINI_KEY"
+         static let unsplashAccessKey = "YOUR_REAL_UNSPLASH_KEY"
+     }
+     ```
+   - Drop your real `GoogleService-Info.plist` (from the Firebase console) into
+     `Edutok/` (also gitignored).
+
+   > Without these the app builds but the feed stays empty and the leaderboard
+   > won't populate — so the keys are what make the screenshots compelling.
+3. **Run the app**: open `Edutok.xcodeproj`, pick an **iPhone 16 Pro** simulator,
+   press **⌘R**. Sign in, enter a topic (e.g. "Roman Empire"), and let the AI
+   generate the feed.
+4. **Capture each screen**: focus the simulator and press **⌘S**
+   (File ▸ Save Screen). macOS saves a device-framed PNG to your **Desktop**.
+5. **Rename and drop them into `docs/`**, then push:
+   ```bash
+   # rename captured PNGs to the names in the table above, then:
+   cp ~/Desktop/{feed,topic,gamification,streak,leaderboard}.png docs/
+   git add docs/*.png
+   git commit -m "docs: add app screenshots"
+   git push
+   ```
+   The README tables and the slots above render them automatically.
 
 > Tip: capture all five in the same simulator/orientation so the table rows line up.


### PR DESCRIPTION
Brings Edutok to parity with the flagship repos: continuous integration, a shared Xcode scheme, an architecture doc, README polish, and live screenshot slots.

## What changed

**CI** (`.github/workflows/ci.yml`)
- Builds the app and runs the `EdutokTests` unit tests on an iOS simulator (`macos-15`, iPhone 16 Pro, `OS=latest`).
- `Secrets.swift` and `GoogleService-Info.plist` are **gitignored**, so CI writes throwaway stubs for both *before* resolving packages — a non-functional `Secrets.swift` (placeholder Gemini/Unsplash keys) and a syntactically valid placeholder `GoogleService-Info.plist`. This lets the project compile and `FirebaseApp.configure()` succeed. **No real keys are committed or used**, and no real backend is contacted during a build/test run.

**Shared scheme** (`Edutok.xcodeproj/xcshareddata/xcschemes/Edutok.xcscheme`)
- Standard app scheme so `xcodebuild -scheme Edutok` works on a clean checkout (none existed before). Builds the `Edutok` app target; tests the `EdutokTests` target.

**Build-blocking fixes** (separate commit)
- A fresh checkout did **not** compile under the current Swift toolchain. Fixed two genuine, pre-existing errors so CI can be green:
  - `TopicManager.swift` / `ImageManager.swift`: a local `let response = JSONDecoder()...` shadowed the `(data, response)` tuple from `URLSession`, an *invalid redeclaration*. Renamed the decoded local to `decoded`.
  - `EdutokTests.swift`: used `Date()` without `import Foundation`. Added the import.

**Docs**
- `docs/ARCHITECTURE.md` — new: manager-based architecture, the TikTok-style swipe feed, Gemini flashcard generation + fallback, Firebase Auth/Firestore data model & sync, the gamification system, Unsplash imagery, persistence table, and an ASCII data-flow diagram. Grounded in the actual source; known stubs/limitations called out.
- `README.md` — added the CI badge, a link to the architecture doc, and a live **Screenshots** section.
- `docs/SCREENSHOTS.md` — rewritten with labeled image slots (`feed.png`, `topic.png`, `gamification.png`, `streak.png`, `leaderboard.png`) and a "How to capture" guide.

## Notes for the reviewer
- **Screenshots are placeholders.** The image slots reference `docs/*.png` that don't exist yet, so they render as broken until you drop the PNGs in — that's expected.
- **CI uses stub Firebase/Secrets config, not real keys.**

## Verification
Ran locally the exact command CI runs (Xcode 26.5, iOS 26.5 simulator): `xcodebuild test -scheme Edutok -only-testing:EdutokTests` → **TEST SUCCEEDED**, all **10** Swift Testing tests passed. Scheme XML and the stub plist were validated with `xmllint` / `plutil -lint`.

Do not merge yet.